### PR TITLE
Remove support for pypy-5.4 in Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ python:
   - "2.7"
   - "3.5"
   - "3.6"
-  - "pypy-5.4"
 env:
   - PRESTO_VERSION=0.202
 services:


### PR DESCRIPTION
Based on @ggreg 's comment https://github.com/prestosql/python-client/pull/2#issuecomment-573450675.